### PR TITLE
Export PNGs with white background

### DIFF
--- a/app/domain-story-modeler/features/export/pngDownload.js
+++ b/app/domain-story-modeler/features/export/pngDownload.js
@@ -33,6 +33,12 @@ export function downloadPNG() {
     tempCanvas.height = height + 10;
 
     let ctx = tempCanvas.getContext('2d');
+
+    // fill with white background
+    ctx.rect(0, 0, tempCanvas.width, tempCanvas.height);
+    ctx.fillStyle = "white";
+    ctx.fill();
+
     ctx.drawImage(image, 0, 0);
 
     let png64 = tempCanvas.toDataURL('image/png');


### PR DESCRIPTION
The PNG export currently creates an image with transparent background. 

This becomes an annoying issue, because a lot of the project management tools nowadays support "dark mode". With dark backgrounds, the exported graphic becomes unreadable because the black lines have no good contrast:

![image](https://user-images.githubusercontent.com/1311398/113866322-76035b80-97ad-11eb-94ea-97b82223f244.png)

This PR fills the background with white before exporting it.

Alternatively we could offer a third export button: "SVG, PNG, PNG (white background)".
What do you think?

Tom
