### PR TITLE
Fallback für Schriftart in body ergänzt

### DIFF
--- a/app/domain-story.css
+++ b/app/domain-story.css
@@ -3,7 +3,7 @@ body {
   height: 100%;
   width: 100%;
   position: absolute;
-  font-family: Helvetica;
+  font-family: 'Helvetica', 'Arial', sans-serif;
   overflow: hidden;
   margin: 0px;
 }


### PR DESCRIPTION
Heute zufällig bei der Nutzung des Modelers in Firefox auf Linux aufgefallen, dass die Schriftart etwas komisch aussah. Problem war, dass es dort kein Helvetica gab und der Default-Font ne Serifen-Schrift war. 