### PR TITLE
Add Story-As-Spec export option

### DIFF
--- a/src/app/tools/export/services/domain-story-step-builder.service.spec.ts
+++ b/src/app/tools/export/services/domain-story-step-builder.service.spec.ts
@@ -1,0 +1,145 @@
+import { TestBed } from '@angular/core/testing';
+import { MockProviders } from 'ng-mocks';
+import { DomainStoryStepBuilderService } from './domain-story-step-builder.service';
+import { ElementRegistryService } from 'src/app/tools/modeler/services/element-registry.service';
+import { ElementTypes } from 'src/app/domain/entities/element-types';
+import { testCanvasObject } from 'src/app/domain/entities/canvas-object';
+import { testActivityCanvasObject } from 'src/app/domain/entities/activity-canvas-object';
+import { ActivityCanvasObject } from 'src/app/domain/entities/activity-canvas-object';
+import { CanvasObject } from 'src/app/domain/entities/canvas-object';
+import { BusinessObject } from 'src/app/domain/entities/business-object';
+import { ActivityBusinessObject } from 'src/app/domain/entities/activity-business-object';
+
+function makeCanvasObject(
+  overrides: Partial<Omit<CanvasObject, 'businessObject'>> & {
+    businessObject?: Partial<BusinessObject>;
+  },
+): CanvasObject {
+  return {
+    ...testCanvasObject,
+    ...overrides,
+    businessObject: {
+      ...testCanvasObject.businessObject,
+      ...(overrides.businessObject ?? {}),
+    },
+  } as CanvasObject;
+}
+
+function makeActivity(
+  overrides: Partial<Omit<ActivityCanvasObject, 'businessObject'>> & {
+    businessObject?: Partial<ActivityBusinessObject>;
+  },
+): ActivityCanvasObject {
+  return {
+    ...testActivityCanvasObject,
+    ...overrides,
+    businessObject: {
+      ...testActivityCanvasObject.businessObject,
+      ...(overrides.businessObject ?? {}),
+    },
+  } as ActivityCanvasObject;
+}
+
+describe('DomainStoryStepBuilderService', () => {
+  let service: DomainStoryStepBuilderService;
+  let elementRegistryService: ElementRegistryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MockProviders(ElementRegistryService)],
+    });
+    service = TestBed.inject(DomainStoryStepBuilderService);
+    elementRegistryService = TestBed.inject(ElementRegistryService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('builds a step from a simple actor -> activity -> workobject chain', () => {
+    const actor = makeCanvasObject({
+      id: 'actor1',
+      type: ElementTypes.ACTOR,
+      businessObject: { name: 'Customer' },
+      outgoing: [],
+      incoming: [],
+    });
+    const workObject = makeCanvasObject({
+      id: 'wo1',
+      type: ElementTypes.WORKOBJECT,
+      businessObject: { name: 'Order' },
+      outgoing: [],
+      incoming: [],
+    });
+    const activity = makeActivity({
+      id: 'act1',
+      source: actor,
+      target: workObject,
+      businessObject: { number: 1, name: 'places' },
+    });
+
+    spyOn(elementRegistryService, 'getActivitiesFromActors').and.returnValue([
+      activity,
+    ]);
+
+    const result = service.build();
+
+    expect(result.steps).toEqual([
+      {
+        stepNumber: 1,
+        stepParts: ['Customer', 'places', 'Order'],
+        annotations: [],
+      },
+    ]);
+    expect(result.actors).toEqual(new Set(['Customer']));
+    expect(result.workObjects).toEqual(new Set(['Order']));
+  });
+
+  it('collects text-annotation lines attached to the target work object', () => {
+    const actor = makeCanvasObject({
+      id: 'actor1',
+      type: ElementTypes.ACTOR,
+      businessObject: { name: 'Customer' },
+      outgoing: [],
+      incoming: [],
+    });
+    const annotation = makeCanvasObject({
+      id: 'note1',
+      type: ElementTypes.TEXTANNOTATION,
+      businessObject: { name: '' } as any,
+    });
+    (annotation.businessObject as any).text = 'must be paid within 30 days';
+    const workObject = makeCanvasObject({
+      id: 'wo1',
+      type: ElementTypes.WORKOBJECT,
+      businessObject: { name: 'Order' },
+      outgoing: [
+        {
+          ...testActivityCanvasObject,
+          businessObject: {
+            ...testActivityCanvasObject.businessObject,
+            number: undefined,
+          },
+          target: annotation,
+        } as ActivityCanvasObject,
+      ],
+      incoming: [],
+    });
+    const activity = makeActivity({
+      id: 'act1',
+      source: actor,
+      target: workObject,
+      businessObject: { number: 1, name: 'places' },
+    });
+
+    spyOn(elementRegistryService, 'getActivitiesFromActors').and.returnValue([
+      activity,
+    ]);
+
+    const result = service.build();
+
+    expect(result.steps[0].annotations).toEqual([
+      { elementName: 'Order', lines: ['must be paid within 30 days'] },
+    ]);
+  });
+});

--- a/src/app/tools/export/services/domain-story-step-builder.service.ts
+++ b/src/app/tools/export/services/domain-story-step-builder.service.ts
@@ -1,0 +1,192 @@
+import { inject, Injectable } from '@angular/core';
+import { ElementRegistryService } from 'src/app/tools/modeler/services/element-registry.service';
+import { ElementTypes } from 'src/app/domain/entities/element-types';
+import { ActivityCanvasObject } from 'src/app/domain/entities/activity-canvas-object';
+import { CanvasObject } from 'src/app/domain/entities/canvas-object';
+
+export interface DomainStoryStepAnnotation {
+  elementName: string;
+  lines: string[];
+}
+
+export interface DomainStoryStep {
+  stepNumber: number | string;
+  stepParts: string[];
+  annotations: DomainStoryStepAnnotation[];
+}
+
+export interface DomainStoryStepData {
+  steps: DomainStoryStep[];
+  actors: Set<string>;
+  workObjects: Set<string>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DomainStoryStepBuilderService {
+  private readonly elementRegistryService = inject(ElementRegistryService);
+
+  build(): DomainStoryStepData {
+    const activities = this.elementRegistryService.getActivitiesFromActors();
+    const actors = new Set<string>();
+    const workObjects = new Set<string>();
+
+    const steps = activities.map((a) => this.buildStep(a, actors, workObjects));
+
+    return { steps, actors, workObjects };
+  }
+
+  private buildStep(
+    activity: ActivityCanvasObject,
+    actors: Set<string>,
+    workObjects: Set<string>,
+  ): DomainStoryStep {
+    const stepNumber = activity.businessObject.number ?? '';
+    const activityName = activity.businessObject.name ?? '';
+    const sourceCanvas = activity.source;
+    const targetCanvas = activity.target;
+    const sourceName = sourceCanvas?.businessObject?.name ?? '';
+    const targetName = targetCanvas?.businessObject?.name ?? '';
+
+    if (sourceName) actors.add(sourceName);
+
+    const stepParts = [sourceName, activityName, targetName].filter(Boolean);
+    const annotations: DomainStoryStepAnnotation[] = [];
+
+    this.collectAnnotations(sourceCanvas, sourceName, annotations);
+    this.processTarget(
+      targetCanvas,
+      targetName,
+      stepParts,
+      annotations,
+      actors,
+      workObjects,
+    );
+
+    return { stepNumber, stepParts, annotations };
+  }
+
+  private processTarget(
+    target: CanvasObject,
+    targetName: string,
+    stepParts: string[],
+    annotations: DomainStoryStepAnnotation[],
+    actors: Set<string>,
+    workObjects: Set<string>,
+  ): void {
+    if (target?.type?.includes(ElementTypes.WORKOBJECT)) {
+      workObjects.add(targetName);
+      this.collectAnnotations(target, targetName, annotations);
+      this.followWorkObjectChain(
+        target,
+        stepParts,
+        annotations,
+        actors,
+        workObjects,
+      );
+    } else if (target?.type?.includes(ElementTypes.ACTOR)) {
+      actors.add(targetName);
+      this.collectAnnotations(target, targetName, annotations);
+    }
+  }
+
+  private followWorkObjectChain(
+    workObject: CanvasObject,
+    stepParts: string[],
+    annotations: DomainStoryStepAnnotation[],
+    actors: Set<string>,
+    workObjects: Set<string>,
+  ): void {
+    for (const outgoing of workObject.outgoing ?? []) {
+      if (outgoing.businessObject?.number) continue;
+      if (outgoing.target?.type?.includes(ElementTypes.TEXTANNOTATION))
+        continue;
+
+      const connLabel = outgoing.businessObject?.name ?? '';
+      const nextName = outgoing.target?.businessObject?.name ?? '';
+      if (connLabel) stepParts.push(connLabel);
+      if (nextName) stepParts.push(nextName);
+
+      this.registerAndAnnotate(
+        outgoing.target,
+        nextName,
+        annotations,
+        actors,
+        workObjects,
+      );
+    }
+  }
+
+  private registerAndAnnotate(
+    element: CanvasObject,
+    name: string,
+    annotations: DomainStoryStepAnnotation[],
+    actors: Set<string>,
+    workObjects: Set<string>,
+  ): void {
+    if (element?.type?.includes(ElementTypes.ACTOR)) {
+      actors.add(name);
+    } else if (element?.type?.includes(ElementTypes.WORKOBJECT)) {
+      workObjects.add(name);
+    }
+    this.collectAnnotations(element, name, annotations);
+  }
+
+  private collectAnnotations(
+    element: CanvasObject,
+    elementName: string,
+    annotations: DomainStoryStepAnnotation[],
+  ): void {
+    const lines = this.getTextAnnotationLines(element);
+    if (lines.length > 0) {
+      annotations.push({ elementName, lines });
+    }
+  }
+
+  private annotationText(element: CanvasObject): string {
+    // Text annotation content is stored in businessObject.text, not businessObject.name
+    // (name is always empty ""; see domainStoryRenderer.js line 529)
+    const bo = element.businessObject as any;
+    return bo?.text || bo?.name || '';
+  }
+
+  private getTextAnnotationLines(element: CanvasObject): string[] {
+    if (!element) return [];
+
+    const seen = new Set<string>();
+    const lines: string[] = [];
+
+    const push = (text: string) =>
+      text
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .forEach((l) => {
+          if (!seen.has(l)) {
+            seen.add(l);
+            lines.push(l);
+          }
+        });
+
+    for (const outgoing of element.outgoing ?? []) {
+      if (
+        !outgoing.businessObject?.number &&
+        outgoing.target?.type?.includes(ElementTypes.TEXTANNOTATION)
+      ) {
+        push(this.annotationText(outgoing.target));
+      }
+    }
+
+    for (const incoming of element.incoming ?? []) {
+      if (
+        !incoming.businessObject?.number &&
+        incoming.source?.type?.includes(ElementTypes.TEXTANNOTATION)
+      ) {
+        push(this.annotationText(incoming.source));
+      }
+    }
+
+    return lines;
+  }
+}

--- a/src/app/tools/export/services/export.service.spec.ts
+++ b/src/app/tools/export/services/export.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { ExportService } from 'src/app/tools/export/services/export.service';
 import { HtmlPresentationService } from './html-presentation.service';
+import { StoryAsSpecService } from './story-as-spec.service';
 import { MockModule, MockService } from 'ng-mocks';
 import { IconSetImportExportService } from '../../icon-set-config/services/icon-set-import-export.service';
 import { PngService } from './png.service';
@@ -10,6 +11,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 
 describe('ExportService', () => {
   let service: ExportService;
+  let storyAsSpecService: StoryAsSpecService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -31,12 +33,27 @@ describe('ExportService', () => {
           provide: SvgService,
           useValue: MockService(SvgService),
         },
+        {
+          provide: StoryAsSpecService,
+          useValue: MockService(StoryAsSpecService),
+        },
       ],
     });
     service = TestBed.inject(ExportService);
+    storyAsSpecService = TestBed.inject(StoryAsSpecService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('downloadStoryAsSpec generates a story-as-spec summary', () => {
+    spyOn(storyAsSpecService, 'generateStoryAsSpec').and.returnValue(
+      'This Domain Story describes how Test interacts with Thing across 1 step.',
+    );
+
+    service.downloadStoryAsSpec('test-filename');
+
+    expect(storyAsSpecService.generateStoryAsSpec).toHaveBeenCalled();
   });
 });

--- a/src/app/tools/export/services/export.service.ts
+++ b/src/app/tools/export/services/export.service.ts
@@ -7,6 +7,7 @@ import { DirtyFlagService } from 'src/app/tools/modeler/services/dirty-flag.serv
 import { PngService } from 'src/app/tools/export/services/png.service';
 import { SvgService } from 'src/app/tools/export/services/svg.service';
 import { HtmlPresentationService } from './html-presentation.service';
+import { StoryAsSpecService } from './story-as-spec.service';
 import { environment } from '../../../../environments/environment';
 import {
   ExportDialogData,
@@ -39,6 +40,7 @@ export class ExportService {
   private readonly modelerService = inject(ModelerService);
   private readonly dialogService = inject(DialogService);
   private readonly snackbar = inject(MatSnackBar);
+  private readonly storyAsSpecService = inject(StoryAsSpecService);
 
   private readonly fileNameSignal = signal('');
 
@@ -131,6 +133,12 @@ export class ExportService {
     }
   }
 
+  downloadStoryAsSpec(filename: string): void {
+    this.fileNameSignal.set(filename);
+    const summary = this.storyAsSpecService.generateStoryAsSpec();
+    downloadFile(summary, 'data:text/markdown;charset=utf-8,', filename, '.md');
+  }
+
   openDownloadDialog() {
     if (this.isDomainStoryExportable()) {
       const SVGDownloadOption = new ExportOption(
@@ -165,6 +173,11 @@ export class ExportService {
         'Download an HTML-Presentation. This does not include the Domain-Story!',
         (filename: string) => this.downloadHTMLPresentation(filename),
       );
+      const StoryAsSpecDownloadOption = new ExportOption(
+        'Story-As-Spec',
+        'Download a lean, plain-text flow summary (actors, activities, objects) generated from the Domain Story.',
+        (filename: string) => this.downloadStoryAsSpec(filename),
+      );
 
       const config = new MatDialogConfig();
       config.disableClose = false;
@@ -174,6 +187,7 @@ export class ExportService {
         EGNDownloadOption,
         PNGDownloadOption,
         HTMLDownloadOption,
+        StoryAsSpecDownloadOption,
       ]);
 
       this.dialogService.openDialog(ExportDialogComponent, config);

--- a/src/app/tools/export/services/story-as-spec.service.spec.ts
+++ b/src/app/tools/export/services/story-as-spec.service.spec.ts
@@ -1,0 +1,160 @@
+import { TestBed } from '@angular/core/testing';
+import { MockProviders } from 'ng-mocks';
+import { StoryAsSpecService } from './story-as-spec.service';
+import { DomainStoryStepBuilderService } from './domain-story-step-builder.service';
+import { PropertiesService } from 'src/app/tools/properties/services/properties.service';
+import { INITIAL_TITLE } from '../../../domain/entities/constants';
+
+describe('StoryAsSpecService', () => {
+  let service: StoryAsSpecService;
+  let stepBuilder: DomainStoryStepBuilderService;
+  let propertiesServiceMock: {
+    title: jasmine.Spy;
+    description: jasmine.Spy;
+  };
+
+  beforeEach(() => {
+    propertiesServiceMock = {
+      title: jasmine.createSpy('title').and.returnValue(INITIAL_TITLE),
+      description: jasmine.createSpy('description').and.returnValue(''),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        MockProviders(DomainStoryStepBuilderService),
+        { provide: PropertiesService, useValue: propertiesServiceMock },
+      ],
+    });
+    service = TestBed.inject(StoryAsSpecService);
+    stepBuilder = TestBed.inject(DomainStoryStepBuilderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('renders a Story header, Goal in Context, and numbered Scenario with a plain 3-part step', () => {
+    propertiesServiceMock.title.and.returnValue('Event Review');
+    propertiesServiceMock.description.and.returnValue(
+      'Event Owner wants to submit an event and get it reviewed',
+    );
+    spyOn(stepBuilder, 'build').and.returnValue({
+      steps: [
+        {
+          stepNumber: 1,
+          stepParts: ['Event Owner', 'registers', 'informations'],
+          annotations: [
+            {
+              elementName: 'informations',
+              lines: [
+                'Auth can be made by Google',
+                'Normal email address can be registered',
+              ],
+            },
+          ],
+        },
+      ],
+      actors: new Set(['Event Owner']),
+      workObjects: new Set(['informations']),
+    });
+
+    const spec = service.generateStoryAsSpec();
+
+    expect(spec).toContain('Story: Event Review');
+    expect(spec).toContain(
+      'Goal in Context: Event Owner wants to submit an event and get it reviewed',
+    );
+    expect(spec).not.toContain('Trigger:');
+    expect(spec).toContain('Scenario:');
+    expect(spec).toContain(
+      '1. Event Owner registers informations\n   (Auth can be made by Google; Normal email address can be registered)',
+    );
+    expect(spec).toContain('Actors: Event Owner');
+    expect(spec).toContain('Entities: informations');
+  });
+
+  it('appends "with {next}" for a 4-part step (one clean chain continuation)', () => {
+    propertiesServiceMock.title.and.returnValue('Event Review');
+    propertiesServiceMock.description.and.returnValue('Reviewing events');
+    spyOn(stepBuilder, 'build').and.returnValue({
+      steps: [
+        {
+          stepNumber: 1,
+          stepParts: ['Event Owner', 'registers', 'informations', 'System'],
+          annotations: [],
+        },
+      ],
+      actors: new Set(['Event Owner', 'System']),
+      workObjects: new Set(['informations']),
+    });
+
+    const spec = service.generateStoryAsSpec();
+
+    expect(spec).toContain('1. Event Owner registers informations with System');
+  });
+
+  it('falls back to the arrow-chain format for a step with 5+ parts (embedded connector label)', () => {
+    propertiesServiceMock.title.and.returnValue('Event Review');
+    propertiesServiceMock.description.and.returnValue('Reviewing events');
+    spyOn(stepBuilder, 'build').and.returnValue({
+      steps: [
+        {
+          stepNumber: 4,
+          stepParts: [
+            'Event Root',
+            'rejects',
+            'Rejected event',
+            'triggers',
+            'System',
+          ],
+          annotations: [
+            {
+              elementName: 'Rejected event',
+              lines: ['Missing mandatory fields', 'Invalid event dates'],
+            },
+          ],
+        },
+      ],
+      actors: new Set(['Event Root', 'System']),
+      workObjects: new Set(['Rejected event']),
+    });
+
+    const spec = service.generateStoryAsSpec();
+
+    expect(spec).toContain(
+      '4. Event Root → rejects → Rejected event → triggers → System\n   (Missing mandatory fields; Invalid event dates)',
+    );
+  });
+
+  it('falls back to TODO placeholders for header, scenario, actors, and entities when there is no story data, and omits Goal in Context and Trigger entirely', () => {
+    spyOn(stepBuilder, 'build').and.returnValue({
+      steps: [],
+      actors: new Set(),
+      workObjects: new Set(),
+    });
+
+    const spec = service.generateStoryAsSpec();
+
+    expect(spec).toContain('Story: Story Name');
+    expect(spec).not.toContain('Goal in Context');
+    expect(spec).not.toContain('Trigger:');
+    expect(spec).toContain('1. TODO: Describe the flow.');
+    expect(spec).toContain('Actors: TODO: List actors.');
+    expect(spec).toContain('Entities: TODO: List entities.');
+  });
+
+  it('falls back to a 1-based index when a step has no stepNumber', () => {
+    spyOn(stepBuilder, 'build').and.returnValue({
+      steps: [
+        { stepNumber: '', stepParts: ['A', 'does', 'X'], annotations: [] },
+        { stepNumber: '', stepParts: ['B', 'does', 'Y'], annotations: [] },
+      ],
+      actors: new Set(['A', 'B']),
+      workObjects: new Set(['X', 'Y']),
+    });
+
+    const spec = service.generateStoryAsSpec();
+
+    expect(spec).toContain('1. A does X');
+    expect(spec).toContain('2. B does Y');
+  });
+});

--- a/src/app/tools/export/services/story-as-spec.service.ts
+++ b/src/app/tools/export/services/story-as-spec.service.ts
@@ -1,0 +1,75 @@
+import { inject, Injectable } from '@angular/core';
+import { PropertiesService } from 'src/app/tools/properties/services/properties.service';
+import {
+  INITIAL_DESCRIPTION,
+  INITIAL_TITLE,
+} from '../../../domain/entities/constants';
+import {
+  DomainStoryStep,
+  DomainStoryStepBuilderService,
+} from './domain-story-step-builder.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StoryAsSpecService {
+  private readonly stepBuilder = inject(DomainStoryStepBuilderService);
+  private readonly propertiesService = inject(PropertiesService);
+
+  generateStoryAsSpec(): string {
+    const { steps, actors, workObjects } = this.stepBuilder.build();
+
+    const header = `Story: ${this.resolveTitle()}`;
+    const goalLine = this.buildGoalLine();
+    const stepTexts = steps.map((step) => this.buildStepText(step));
+    const scenarioLines = this.buildScenarioLines(steps, stepTexts).join('\n');
+    const actorsLine = this.buildEntityLine('Actors', actors);
+    const entitiesLine = this.buildEntityLine('Entities', workObjects);
+    const introLines = [header, goalLine].filter(Boolean).join('\n\n');
+
+    return `${introLines}\n\nScenario:\n${scenarioLines}\n\n${actorsLine}\n${entitiesLine}\n`;
+  }
+
+  private resolveTitle(): string {
+    const title = this.propertiesService.title();
+    return title && title !== INITIAL_TITLE ? title : 'Story Name';
+  }
+
+  private buildGoalLine(): string {
+    const description = this.propertiesService.description();
+    const hasDescription = Boolean(
+      description && description !== INITIAL_DESCRIPTION,
+    );
+    return hasDescription ? `Goal in Context: ${description}` : '';
+  }
+
+  private buildStepText(step: DomainStoryStep): string {
+    const [actor, activity, target, ...rest] = step.stepParts;
+    const base = [actor, activity, target].filter(Boolean).join(' ');
+
+    if (rest.length === 0) return base;
+    if (rest.length === 1) return `${base} with ${rest[0]}`;
+    return step.stepParts.join(' → ');
+  }
+
+  private buildScenarioLines(
+    steps: DomainStoryStep[],
+    stepTexts: string[],
+  ): string[] {
+    if (steps.length === 0) return ['1. TODO: Describe the flow.'];
+
+    return steps.map((step, index) => {
+      const number = step.stepNumber !== '' ? step.stepNumber : index + 1;
+      const notes = step.annotations.flatMap((a) => a.lines);
+      const noteLine = notes.length > 0 ? `\n   (${notes.join('; ')})` : '';
+      return `${number}. ${stepTexts[index]}${noteLine}`;
+    });
+  }
+
+  private buildEntityLine(label: string, items: Set<string>): string {
+    const list = [...items].filter(Boolean);
+    return `${label}: ${
+      list.length > 0 ? list.join(', ') : `TODO: List ${label.toLowerCase()}.`
+    }`;
+  }
+}


### PR DESCRIPTION
Adds a Story-As-Spec export option to the Export dialog, generating a lean, OOA&D-style use case document from the Domain Story (Story header, optional Goal in Context, numbered Scenario steps with business-rule annotations, Actors/Entities lists) — useful as clean input for AI spec-generation tools.